### PR TITLE
Fix duplicate zip close and verify export

### DIFF
--- a/backend/routes/import_zip_route.py
+++ b/backend/routes/import_zip_route.py
@@ -183,8 +183,6 @@ def export_assets(db: Session = Depends(get_db)):
     zip_file.writestr("assets.json", json.dumps(export_data, indent=2, ensure_ascii=False))
     zip_file.writestr("categories.json", json.dumps(categories_data, indent=2, ensure_ascii=False))
     zip_file.close()
-
-    zip_file.close()
     zip_buffer.seek(0)
     zip_data = zip_buffer.read()
     return StreamingResponse(


### PR DESCRIPTION
## Summary
- remove duplicate zip_file.close call in export endpoint
- confirm export returns valid zip content

## Testing
- `python - <<'EOF'
import asyncio
from backend.routes.import_zip_route import export_assets
from backend.database import SessionLocal
session = SessionLocal()
response = export_assets(session)
print('media_type', response.media_type)
async def gather_data():
    data = b''
    async for chunk in response.body_iterator:
        data += chunk
    return data
loop = asyncio.new_event_loop()
asyncio.set_event_loop(loop)
zip_data = loop.run_until_complete(gather_data())
loop.close()
print('zip size', len(zip_data))
print('signature', zip_data[:4])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684fd503dde48322a53667689305b53b